### PR TITLE
throw on attempting to inject undefined

### DIFF
--- a/lib/inject.coffee
+++ b/lib/inject.coffee
@@ -1,6 +1,8 @@
 
 
 inject = (cls, args...) ->
+  if cls is undefined
+    throw Error('Cannot inject undefined')
   if cls.scope?.toUpperCase() is 'SINGLETON' and args.length
     throw Error('Cannot assign arguments to a singleton')
 

--- a/test/inject_spec.coffee
+++ b/test/inject_spec.coffee
@@ -78,3 +78,12 @@ describe 'Inject', ->
         done()
 
     new Injector().getInstance(Constd)
+
+  describe 'attempting to inject undefined', ->
+    it 'should give you a helpful error', ->
+      create = ->
+        class TryToInjectUndefined
+          inject undefined
+
+      expect(create).to.throw /Cannot inject undefined/
+


### PR DESCRIPTION
came across this today and was slightly confused - figured a friendlier error
on the "yo cheapskate, you didn't mean to do that" tip might be better than
TypeError: Cannot read property 'scope' of undefined
