### PR TITLE
more specific test for parent injected fields

### DIFF
--- a/test/inject_spec.coffee
+++ b/test/inject_spec.coffee
@@ -8,6 +8,7 @@ class SomeSingleton
   constructor: ->
     @name = 'singleton!'
 
+
 describe 'Inject', ->
   it 'should inject requried fields', ->
     class MyCat
@@ -58,11 +59,12 @@ describe 'Inject', ->
     class Child extends Parent
       childField:   inject(SomeSingleton)
 
-    injector = new Injector()
-    child = injector.getInstance(Child)
+    injector  = new Injector()
+    child     = injector.getInstance(Child)
+    singleton = injector.getInstance(SomeSingleton)
 
-    expect(child.childField).to.exist
-    expect(child.parentField).to.exist
+    expect(child.parentField).to.equal singleton
+    expect(child.parentField).to.equal singleton
     expect(child.childField).to.equal (child.parentField)
 
   it 'should have injected fields in place before the constructor is called', (done) ->


### PR DESCRIPTION
just looked at this guy, there's definitely tests to ensure a child gets a parents injected fields when using coffeescript extends.  changed them to test for equality since the original jawns would pass even if we were getting the object returned by the `inject` function.  which we're not!

here they are if you want them!

![9f1](https://f.cloud.github.com/assets/26769/1526977/3e07b08c-4bed-11e3-92f7-a84b799ac25b.jpg)
