### PR TITLE
VBID-4331 ability to specify class equality

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -1,0 +1,33 @@
+coffee = require 'gulp-coffee'
+gulp   = require 'gulp'
+gutil  = require 'gulp-util'
+mocha  = require 'gulp-mocha'
+
+
+gulp.task 'default', ['build']
+
+
+gulp.task 'build', ->
+  gulp.src './lib/**/*.coffee'
+    .pipe(coffee())
+    .pipe(gulp.dest('build/lib'))
+
+
+  gulp.src './index.coffee'
+    .pipe(coffee())
+    .pipe(gulp.dest('build'))
+
+
+gulp.task 'test', -> exitOnFinish runTests
+
+
+runTests = (reporter='spec', bail=true) ->
+  gulp.src './test/**/*.coffee', read: false
+    .pipe(mocha(reporter: reporter))
+    .on 'error', (e) -> gutil.log e.toString()
+
+
+exitOnFinish = (func, args...) ->
+  func(args...)
+    .on 'error', -> process.exit 1
+    .on 'end',   -> process.exit 0

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,25 +1,2 @@
 require('coffee-script').register();
-
-var gulp    = require('gulp'),
-    coffee  = require('gulp-coffee'),
-    mocha   = require('gulp-mocha');
-
-
-gulp.task('build', function() {
-  gulp.src('./lib/**/*.coffee')
-    .pipe(coffee())
-    .pipe(gulp.dest('build/lib'))
-
-  gulp.src('./index.coffee')
-    .pipe(coffee())
-    .pipe(gulp.dest('build'))
-});
-
-gulp.task('test', function() {
-  gulp.src('./test/**/*.coffee', {'read': false})
-    .pipe(mocha({
-      reporter: 'spec'
-    }))
-})
-
-gulp.task('default', ['build']);
+require('./gulpfile.coffee');

--- a/lib/binder.coffee
+++ b/lib/binder.coffee
@@ -1,10 +1,10 @@
-
 class Binding
   matches: (proto) ->
     throw Error('Binding.matches not implemented')
 
   create: (defaultFactory) ->
     defaultFactory()
+
 
 class ClassBinding extends Binding
   constructor: (@iface) ->
@@ -30,7 +30,12 @@ class ClassBinding extends Binding
     this
 
   matches: (cls) ->
-    cls is @iface
+    cls is @iface or @_clsIdMatches(cls)
+
+  _clsIdMatches: (cls) ->
+    id = cls.__honk_clsid
+    id? and id is @iface.__honk_clsid
+
 
 class ConstantBinding extends Binding
   constructor: (@name) ->
@@ -42,6 +47,7 @@ class ConstantBinding extends Binding
 
   create: ->
     @value
+
 
 class Binder
   constructor: ->

--- a/lib/class_map.coffee
+++ b/lib/class_map.coffee
@@ -16,4 +16,5 @@ class ClassMap
     cls[@_field] or= @_nextId++
     @_classes[cls[@_field]] = instance
 
+
 module.exports = ClassMap

--- a/lib/inject.coffee
+++ b/lib/inject.coffee
@@ -1,5 +1,3 @@
-
-
 inject = (cls, args...) ->
   if cls is undefined
     throw Error('Cannot inject undefined')
@@ -9,5 +7,6 @@ inject = (cls, args...) ->
   _requiresInjection_: true
   cls:  cls
   args: args
+
 
 module.exports = inject

--- a/lib/injector.coffee
+++ b/lib/injector.coffee
@@ -1,8 +1,10 @@
 ClassMap = require './class_map'
 
+
 name = (injectable) ->
   if injectable.name? then injectable.name
   else "'#{injectable}'"
+
 
 class Injector
   constructor: (@binders...) ->
@@ -51,5 +53,6 @@ class Injector
     for k, v of ptype
       if v? and v._requiresInjection_
         instance[k] = @getInstance(v.cls, v.args...)
+
 
 module.exports = Injector

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name":     "honk-di",
-  "version":  "0.0.10",
+  "version":  "1.0.0",
   "files":    ["build", "build/lib"],
   "main":     "build/index.js",
+  "scripts": {
+    "test": "gulp test"
+  },
   "dependencies": {
   },
   "devDependencies": {

--- a/test/binder_spec.coffee
+++ b/test/binder_spec.coffee
@@ -78,3 +78,22 @@ describe 'A binder', ->
 
     binder = new ConstantBinder()
     expect(binder.bindings).to.have.length 1
+
+  it 'should resolve match based on matching __honk_clsid', ->
+    class Class3
+      name: 'Class 3'
+
+    class Class1
+      @__honk_clsid: 'this is class one'
+
+    class Class2
+      @__honk_clsid: 'this is class one'
+
+    class TestClassEqualityBinder extends Binder
+      configure: ->
+        @bind(Class1).to(Class3)
+
+    binder = new TestClassEqualityBinder(Class3)
+    expect(binder.bindings).to.have.length 1
+    matched = binder.bindings[0].matches(Class2)
+    expect(matched).to.be.true

--- a/test/inject_spec.coffee
+++ b/test/inject_spec.coffee
@@ -88,4 +88,3 @@ describe 'Inject', ->
           inject undefined
 
       expect(create).to.throw /Cannot inject undefined/
-

--- a/test/name_conflict_spec.coffee
+++ b/test/name_conflict_spec.coffee
@@ -3,6 +3,7 @@ expect = require('chai').expect
 Injector       = require('../lib/injector')
 TestSingleton2 = require('./test_singleton')
 
+
 class TestSingleton
   @scope: 'SINGLETON'
   name:   'Test Singleton'

--- a/test/test_singleton.coffee
+++ b/test/test_singleton.coffee
@@ -1,6 +1,6 @@
-
 class TestSingleton
   @scope: 'SINGLETON'
   name:   'Test Singleton 2'
+
 
 module.exports = TestSingleton


### PR DESCRIPTION
use SomeClass.__honk_clsid as an alternate way to specify class
equality.

This came up in instances where a project using honk-di depended on
another project using honk-di, where both share a dependency that has an
abstract class, and in both projects that abstract class is bound to an
implementation

this allows the setting of __honk_clsid to say "alright, these are
actually the same thing, this is fine".  this might be a terrible idea
- whitespace cleanup
- move gulpfile.js -> gulpfile.coffee
